### PR TITLE
Property name

### DIFF
--- a/pale/fields/base.py
+++ b/pale/fields/base.py
@@ -13,10 +13,15 @@ class BaseField(object):
     include validation functionality.
     """
 
-    def __init__(self, value_type, description, details=None):
+    def __init__(self,
+                 value_type,
+                 description,
+                 details=None,
+                 property_name=None):
         self.value_type = value_type
         self.description = description
         self.details = details
+        self.property_name = property_name
 
     def _fix_up(self, cls, code_name):
         """Internal helper to name the field after its variable.
@@ -44,7 +49,10 @@ class BaseField(object):
         resources (or, for example, if you decide to implement attribute
         hiding at the field level instead of at the object level).
         """
-        return getattr(obj, name, None)
+        attr_name = name
+        if self.property_name is not None:
+            attr_name = self.property_name
+        return getattr(obj, attr_name, None)
 
     def doc_dict(self):
         """Generate the documentation for this field."""
@@ -59,9 +67,11 @@ class ListField(BaseField):
     """A Field that contains a list of Fields."""
     value_type = 'list'
 
-    def __init__(self, description, details=None, item_type=BaseField):
-        self.description = description
-        self.details = details
+    def __init__(self, description, item_type=BaseField, **kwargs):
+        super(ListField, self).__init__(
+                self.value_type,
+                description,
+                **kwargs)
         self.item_type = item_type
 
     def doc_dict(self):

--- a/pale/fields/base.py
+++ b/pale/fields/base.py
@@ -42,7 +42,8 @@ class BaseField(object):
         """The default field renderer.
 
         This basic renderer assumes that the object has an attribute with
-        the same name as the field.
+        the same name as the field, unless a different field is specified
+        as a `property_name`.
 
         The renderer is also passed the context so that it can be
         propagated to the `_render_serializable` method of nested

--- a/pale/fields/boolean.py
+++ b/pale/fields/boolean.py
@@ -4,7 +4,8 @@ class BooleanField(BaseField):
     """A BaseField whose type is `boolean`."""
     value_type = 'boolean'
 
-    def __init__(self, description, details=None):
-        super(BooleanField, self).__init__(self.value_type,
+    def __init__(self, description, **kwargs):
+        super(BooleanField, self).__init__(
+                self.value_type,
                 description,
-                details)
+                **kwargs)

--- a/pale/fields/integer.py
+++ b/pale/fields/integer.py
@@ -4,6 +4,8 @@ class IntegerField(BaseField):
     """A BaseField whose type is `integer`."""
     value_type = 'integer'
 
-    def __init__(self, description, details=None):
-        self.description = description
-        self.details = details
+    def __init__(self, description, **kwargs):
+        super(IntegerField, self).__init__(
+                self.value_type,
+                description,
+                **kwargs)

--- a/pale/fields/links.py
+++ b/pale/fields/links.py
@@ -19,9 +19,11 @@ class RelativeLinksField(BaseField):
     """
     value_type = "relative links"
 
-    def __init__(self, description, details=None, link_generators=[]):
-        self.description = description
-        self.details = details
+    def __init__(self, description, link_generators=[], **kwargs):
+        super(RelativeLinksField, self).__init__(
+                self.value_type,
+                description,
+                **kwargs)
         self.link_generators = link_generators
 
 

--- a/pale/fields/resource.py
+++ b/pale/fields/resource.py
@@ -10,11 +10,13 @@ class ResourceField(BaseField):
 
     def __init__(self,
             description,
-            details=None,
             resource_type=Resource,
-            subfields=None):
-        self.description = description
-        self.details = details
+            subfields=None,
+            **kwargs):
+        super(ResourceField, self).__init__(
+                self.value_type,
+                description,
+                **kwargs)
         self.resource_type = resource_type
 
         if subfields is None:

--- a/pale/fields/resource.py
+++ b/pale/fields/resource.py
@@ -50,7 +50,7 @@ class ResourceListField(ListField):
             description,
             resource_type=Resource,
             subfields=None,
-            **kwargs)
+            **kwargs):
         super(ResourceListField, self).__init__(
                 description,
                 item_type=self.item_type,

--- a/pale/fields/resource.py
+++ b/pale/fields/resource.py
@@ -34,11 +34,12 @@ class ResourceField(BaseField):
 
     def render(self, obj, name, context):
         if obj is None:
-            output = None
-        else:
-            instance = getattr(obj, name, None)
-            renderer = self.resource_instance._render_serializable
-            output = renderer(instance, context)
+            return None
+        # the base renderer basically just calls getattr, so it will
+        # return the resource here
+        resource = super(ResourceField, self).render(obj, name, context)
+        renderer = self.resource_instance._render_serializable
+        output = renderer(resource, context)
         return output
 
 
@@ -77,9 +78,11 @@ class ResourceListField(ListField):
             return None
 
         output = []
-        list_of_resources = getattr(obj, name, [])
+        # again, the base renderer basically just calls getattr.
+        # We're expecting the attr to be a list, though.
+        resources = super(ResourceListField, self).render(obj, name, context)
         renderer = self.resource_instance._render_serializable
-        for res in list_of_resources:
+        for res in resources:
             item = renderer(res, context)
             output.append(item)
         return output

--- a/pale/fields/resource.py
+++ b/pale/fields/resource.py
@@ -44,16 +44,17 @@ class ResourceField(BaseField):
 
 class ResourceListField(ListField):
     """A Field that contains a list of Fields."""
-    value_type = 'list'
+    item_type = ResourceField
 
     def __init__(self,
             description,
-            details=None,
             resource_type=Resource,
-            subfields=None):
-        self.description = description
-        self.details = details
-        self.item_type = ResourceField
+            subfields=None,
+            **kwargs)
+        super(ResourceListField, self).__init__(
+                description,
+                item_type=self.item_type,
+                **kwargs)
         self.resource_type = resource_type
 
         if subfields is None:

--- a/pale/fields/string.py
+++ b/pale/fields/string.py
@@ -4,6 +4,8 @@ class StringField(BaseField):
     """A BaseField whose type is `string`."""
     value_type = 'string'
 
-    def __init__(self, description, details=None):
-        self.description = description
-        self.details = details
+    def __init__(self, description, **kwargs):
+        super(StringField, self).__init__(
+                self.value_type,
+                description,
+                **kwargs)

--- a/pale/resource.py
+++ b/pale/resource.py
@@ -75,6 +75,10 @@ class Resource(object):
         logging.info("""Careful, you're calling ._render_serializable on the
         base resource, which is probably not what you actually want to be
         doing!""")
+        if obj is None:
+            logging.debug(
+                    "_render_serializable passed a None obj, returning None")
+            return None
         output = {}
         if self._fields_to_render is None:
             return output

--- a/pale/resource.py
+++ b/pale/resource.py
@@ -41,6 +41,7 @@ class Resource(object):
         if cls._default_fields is None:
             cls._default_fields = tuple(cls._fields.keys())
 
+
     def __init__(self, doc_string=None, fields=None):
         """Initialize the resource with the provided doc string and fields.
 
@@ -97,8 +98,9 @@ class ResourceList(Resource):
     """
     _description = "A generic list of Resources"
 
-    def __init__(self, doc_string, item_type):
-        super(ResourceList, self).__init__(doc_string)
+    def __init__(self, doc_string, item_type, **kwargs):
+        kwargs['doc_string'] = doc_string
+        super(ResourceList, self).__init__(**kwargs)
 
         if isinstance(item_type, Resource):
             self._item_resource = item_type

--- a/tests/example_app/api/resources.py
+++ b/tests/example_app/api/resources.py
@@ -20,7 +20,8 @@ class DateTimeResource(Resource):
     minutes = IntegerField("The minutes, between 0 and 59")
     seconds = IntegerField("The seconds, between 0 and 59")
 
-    iso = StringField("The DateTime's ISO representation")
+    isoformat = StringField("The DateTime's ISO representation",
+            property_name='iso')
 
     name = StringField("Your DateTime's name",
             details="This value will be `null` on most DateTimes.  It's "
@@ -31,7 +32,7 @@ class DateTimeResource(Resource):
     _default_fields = ('year',
                        'month',
                        'day',
-                       'iso')
+                       'isoformat')
 
 
     def _render_serializable(self, instance, context):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -12,7 +12,7 @@ class FieldsTests(unittest.TestCase):
     def test_create_base_field(self):
         field = BaseField("integer",
                 "This is a test field",
-                "This is where I put special notes about the field")
+                details="This is where I put special notes about the field")
 
         self.assertEqual(field.value_type, "integer")
         self.assertEqual(field.description, "This is a test field")
@@ -35,17 +35,17 @@ class FieldsTests(unittest.TestCase):
 
     def test_create_string_field(self):
         field = StringField("Your name",
-                "You should expect a real name here, not some mish-mosh")
+                details="You should put a real name here, not some gibberish")
         self.assertEqual(field.value_type, "string")
         self.assertEqual(field.description, "Your name")
         self.assertEqual(field.details,
-                "You should expect a real name here, not some mish-mosh")
+                "You should put a real name here, not some gibberish")
 
         doc = field.doc_dict()
         self.assertEqual(doc["type"], "string")
         self.assertEqual(doc["description"], "Your name")
         self.assertEqual(doc["extended_description"],
-                "You should expect a real name here, not some mish-mosh")
+                "You should put a real name here, not some gibberish")
 
         field = StringField("Your name")
         self.assertIsNone(field.details)
@@ -55,8 +55,8 @@ class FieldsTests(unittest.TestCase):
 
     def test_integer_field(self):
         field = IntegerField("The amount of stuff for your things",
-                "This amount will always be a positive integer, but may "
-                "be only eventually consistent.")
+                details="This amount will always be a positive integer, but "
+                "may be only eventually consistent.")
 
         self.assertEqual(field.value_type, "integer")
         self.assertEqual(field.description,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -86,7 +86,7 @@ class FieldsTests(unittest.TestCase):
 
     def test_list_field_with_no_item_type(self):
         list_no_item_type = ListField("This is a test list field",
-                "You might add information about the list here.")
+                details="You might add information about the list here.")
         self.assertEqual(list_no_item_type.value_type, "list")
         self.assertEqual(list_no_item_type.description,
                 "This is a test list field")
@@ -97,7 +97,7 @@ class FieldsTests(unittest.TestCase):
 
     def test_create_list_field(self):
         field = ListField("This is a test list field",
-                "You might add information about the list here.",
+                details="You might add information about the list here.",
                 item_type=StringField)
         self.assertEqual(field.value_type, "list")
         self.assertEqual(field.description,
@@ -126,7 +126,7 @@ class FieldsTests(unittest.TestCase):
         specify the nested object as simply a nested resource.
         """
         field = ResourceField("This is a test resource field",
-                "Why does this Resource have another Resource?",
+                details="Why does this Resource have another Resource?",
                 resource_type=DateTimeResource)
 
         self.assertEqual(field.value_type, "resource")
@@ -150,7 +150,7 @@ class FieldsTests(unittest.TestCase):
 
     def test_resource_field_no_type(self):
         field = ResourceField("This is a test resource field",
-                "Why does this Resource have another Resource?")
+                details="Why does this Resource have another Resource?")
 
         self.assertEqual(field.value_type, "resource")
         self.assertEqual(field.description,

--- a/tests/test_flask_adapter.py
+++ b/tests/test_flask_adapter.py
@@ -84,8 +84,6 @@ class FlaskAdapterTests(unittest.TestCase):
         self.assertIn('error', resp.json_body)
 
 
-
-
     def test_getting_with_nested_resources(self):
         test_duration = 60 * 1000 # one minute in milliseconds
         resp = self.app.get('/api/time/range', {'duration': test_duration})


### PR DESCRIPTION
Add a `property_name` parameter to field declaration in resources, allowing Pale to generate a map from render key to actual object property that isn't necessarily 1-1.