### PR TITLE
Add lambda tests and implementation

### DIFF
--- a/pale/endpoint.py
+++ b/pale/endpoint.py
@@ -161,6 +161,17 @@ class Endpoint(object):
                 HTML or XML or whatever in the future).
             The rendered JSON text is then returned as the response that should
             be sent by your HTTP framework's routing handler.
+                         *
+                         *
+        ``pre_response_handler``
+            The pre_response_handlers are sepcified by the Endpoint definition,
+            and enable manipulation of the response object before it is
+            returned to the client, but after the response is rendered.
+
+            Because these are instancemethods, they may share instance data
+            from `self` specified in the endpoint's `_handle` method.
+
+
         """
         try:
             self._create_context(request)
@@ -200,6 +211,11 @@ class Endpoint(object):
         except Exception as e:
             logging.exception(e)
             raise e
+
+        if hasattr(self, '_pre_response_handlers') and \
+                isinstance(self._pre_response_handlers, (list, tuple)):
+            for handler in self._pre_response_handlers:
+                handler(self._context, self._context.response)
 
         return self._context.response
 

--- a/tests/example_app/api/endpoints.py
+++ b/tests/example_app/api/endpoints.py
@@ -7,6 +7,11 @@ from tests.example_app.api.resources import (DateTimeResource,
         DateTimeRangeResource)
 
 
+def add_cors_header(context, response):
+    """Adds a CORs definition to the response header."""
+    response.headers['Access-Control-Allow-Origin'] = "*"
+
+
 class CurrentTimeEndpoint(Endpoint):
     """An API endpoint to get the current time."""
     _http_method = "GET"
@@ -17,6 +22,8 @@ class CurrentTimeEndpoint(Endpoint):
         "The DateTimeResource representation of the current time on the "
         "server.",
         fields=DateTimeResource._all_fields())
+
+    _pre_response_handlers = (add_cors_header, )
 
     def _handle(self, context):
         now = DateTimeModel(datetime.datetime.utcnow())

--- a/tests/example_app/api/resources.py
+++ b/tests/example_app/api/resources.py
@@ -23,6 +23,9 @@ class DateTimeResource(Resource):
     isoformat = StringField("The DateTime's ISO representation",
             property_name='iso')
 
+    eurodate = StringField("The date in DD.MM.YYYY format",
+            value=lambda item: item.timestamp.strftime("%d.%m.%Y"))
+
     name = StringField("Your DateTime's name",
             details="This value will be `null` on most DateTimes.  It's "
             "only set when the DateTime is created with `/parse_time/` "

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import datetime
 
 

--- a/tests/test_flask_adapter.py
+++ b/tests/test_flask_adapter.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+import datetime
 import unittest
 
 from webtest import TestApp
@@ -27,6 +29,7 @@ class FlaskAdapterTests(unittest.TestCase):
 
 
     def test_successful_get_without_params(self):
+        now = datetime.datetime.now()
         resp = self.app.get('/api/time/current')
         self.assertEqual(resp.status_code, 200)
 
@@ -42,6 +45,8 @@ class FlaskAdapterTests(unittest.TestCase):
         expected_fields = DateTimeResource._all_fields()
 
         self.assertExpectedFields(returned_time, expected_fields)
+        self.assertEqual(returned_time['eurodate'],
+                now.strftime("%d.%m.%Y"))
 
 
     def test_successful_post_with_required_params(self):

--- a/tests/test_flask_adapter.py
+++ b/tests/test_flask_adapter.py
@@ -32,6 +32,8 @@ class FlaskAdapterTests(unittest.TestCase):
         now = datetime.datetime.now()
         resp = self.app.get('/api/time/current')
         self.assertEqual(resp.status_code, 200)
+        self.assertIn("Access-Control-Allow-Origin", resp.headers)
+        self.assertEqual(resp.headers["Access-Control-Allow-Origin"], '*')
 
         # the 'time' value was set in the endpoint handler
         self.assertIn('time', resp.json_body)


### PR DESCRIPTION
Add a `value` parameter to fields that allow us to specify a lambda for retrieving the field.  The lambda runs with the instance of the `_underlying_model` as its single argument.