### PR TITLE
Framework for parsing JSON Merge PATCH HTTP requests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,16 @@
+machine:
+  python:
+    version: 2.7.9
+
 dependencies:
   pre:
     - pip install -U -r tests/requirements.txt
+
+test:
+  pre:
+    - ln -s $CIRCLE_TEST_REPORTS/javascript.xml report.xml
+  override:
+    - nosetests --logging-clear-handlers --logging-level=INFO --with-xunit --xunit-file=$CIRCLE_TEST_REPORTS/python.xml:
+        parallel: true
+        files:
+            - tests/**/test*.py

--- a/pale/__init__.py
+++ b/pale/__init__.py
@@ -19,7 +19,7 @@ try:
     """Google App Engine won't let you read a file from the file system like
     this, so __version__ will be different on a GAE server when used in
     production.  In real world use cases, we don't really expect this to be
-    a problem, since the __version__ string is usually just useful for 
+    a problem, since the __version__ string is usually just useful for
     debugging."""
     with open(path.join(path.dirname(__file__), 'VERSION')) as version_file:
         __version__ = version_file.read().strip()

--- a/pale/__init__.py
+++ b/pale/__init__.py
@@ -12,7 +12,7 @@ from . import arguments
 from . import config
 from . import context
 from . import doc
-from .endpoint import Endpoint, PatchEndpoint
+from .endpoint import Endpoint, PatchEndpoint, ResourcePatch
 from .resource import NoContentResource, Resource, ResourceList
 
 try:

--- a/pale/__init__.py
+++ b/pale/__init__.py
@@ -12,7 +12,7 @@ from . import arguments
 from . import config
 from . import context
 from . import doc
-from .endpoint import Endpoint
+from .endpoint import Endpoint, PatchEndpoint
 from .resource import NoContentResource, Resource, ResourceList
 
 try:
@@ -59,7 +59,8 @@ def extract_endpoints(api_module):
     instances = []
 
     for cls in classes:
-        if cls != Endpoint and Endpoint in inspect.getmro(cls):
+        if cls not in (Endpoint, PatchEndpoint) and \
+                Endpoint in inspect.getmro(cls):
             instances.append(cls())
     return instances
 

--- a/pale/adapters/flask.py
+++ b/pale/adapters/flask.py
@@ -77,6 +77,7 @@ class DefaultFlaskContext(pale.context.DefaultContext):
         self.headers = request.headers
         self.cookies = request.cookies
         self.request = request
+        self.body = request.data
         self._raw_args = self.build_args_from_request(request)
         self.route_args = request.view_args
         self.current_user = None

--- a/pale/adapters/webapp2.py
+++ b/pale/adapters/webapp2.py
@@ -101,10 +101,7 @@ class DefaultWebapp2Context(pale.context.DefaultContext):
         self.headers = request.headers
         self.cookies = request.cookies
         self.request = request
-        try:
-            self.body = request.body
-        except AttributeError:
-            self.body = None
+        self.body = request.body
         self._raw_args = self.build_args_from_request(request)
         self.route_args = request.route_args
         self.route_kwargs = request.route_kwargs

--- a/pale/adapters/webapp2.py
+++ b/pale/adapters/webapp2.py
@@ -101,7 +101,10 @@ class DefaultWebapp2Context(pale.context.DefaultContext):
         self.headers = request.headers
         self.cookies = request.cookies
         self.request = request
-        self.body = request.body
+        try:
+            self.body = request.body
+        except AttributeError:
+            self.body = None
         self._raw_args = self.build_args_from_request(request)
         self.route_args = request.route_args
         self.route_kwargs = request.route_kwargs

--- a/pale/adapters/webapp2.py
+++ b/pale/adapters/webapp2.py
@@ -7,6 +7,15 @@ import pale
 RESPONSE_CLASS = webapp2.Response
 
 
+try:
+    """webapp2 does not support the PATCH method at the time this code was
+    written. This patch appends the PATCH method."""
+    allowed_methods = webapp2.WSGIApplication.allowed_methods
+    new_allowed_methods = allowed_methods.union(('PATCH',))
+    webapp2.WSGIApplication.allowed_methods = new_allowed_methods
+except Exception, exc:
+    logging.warn("Failed to monkeypatch webapp2: %r", exc)
+
 def pale_webapp2_request_handler_generator(pale_endpoint):
     """Generate a webapp2.RequestHandler class for the pale endpoint.
 
@@ -92,6 +101,7 @@ class DefaultWebapp2Context(pale.context.DefaultContext):
         self.headers = request.headers
         self.cookies = request.cookies
         self.request = request
+        self.body = request.body
         self._raw_args = self.build_args_from_request(request)
         self.route_args = request.route_args
         self.route_kwargs = request.route_kwargs

--- a/pale/endpoint.py
+++ b/pale/endpoint.py
@@ -352,3 +352,30 @@ class Endpoint(object):
 
         # Add default json response type.
         self._context.response.headers["Content-Type"] = "application/json"
+
+class PatchEndpoint(Endpoint):
+    """Provides a base endpoint for implementing JSON Merge Patch requests.
+    See RFC 7386 @ https://tools.ietf.org/html/rfc7386
+    """
+
+    MERGE_CONTEXT_TYPE = 'application/merge-patch+json'
+    _http_method = "PATCH"
+
+    def _handle_patch(self, context, data):
+        raise NotImplementedError("%s should override _handle_patch" %
+            self.__class__.__name__)
+
+    def _handle(self, context):
+        if (context.headers.get('Content-Type').lower() !=
+                self.MERGE_CONTEXT_TYPE):
+            raise APIError.UnsupportedMedia("PATCH expects content-type %r" %
+                self.MERGE_CONTEXT_TYPE)
+
+        try:
+            data = json.loads(context.body)
+        except:
+            raise APIError.UnprocessableEntity(
+                "Could not decode JSON from request payload.")
+
+        return self._handle_patch(context, data)
+

--- a/pale/endpoint.py
+++ b/pale/endpoint.py
@@ -390,6 +390,18 @@ class ResourcePatch(object):
                 # Cast value and store
                 dt[k] = self.cast_value(field, v)
 
+    def apply_to_model(self, dt):
+        model = self.resource._underlying_model
+        for k,v in self.patch.iteritems():
+            field = self.get_field_from_resource(k)
+            if isinstance(v, dict):
+                # Recursive application.
+                patch = ResourcePatch(v, field)
+                patch.apply_to_model(dt[k])
+            else:
+                # Cast value and set
+                setattr(dt, k, self.cast_value(field, v))
+
 class PatchEndpoint(Endpoint):
     """Provides a base endpoint for implementing JSON Merge Patch requests.
     See RFC 7386 @ https://tools.ietf.org/html/rfc7386

--- a/pale/endpoint.py
+++ b/pale/endpoint.py
@@ -402,12 +402,13 @@ class ResourcePatch(object):
                 # Cast value and set
                 setattr(dt, k, self.cast_value(field, v))
 
+
 class PatchEndpoint(Endpoint):
     """Provides a base endpoint for implementing JSON Merge Patch requests.
     See RFC 7386 @ https://tools.ietf.org/html/rfc7386
     """
 
-    MERGE_CONTEXT_TYPE = 'application/merge-patch+json'
+    MERGE_CONTENT_TYPE = 'application/merge-patch+json'
     _http_method = "PATCH"
 
     def _handle_patch(self, context, patch):
@@ -422,9 +423,9 @@ class PatchEndpoint(Endpoint):
                 self.__class__.__name__)
 
         if (context.headers.get('Content-Type').lower() !=
-                self.MERGE_CONTEXT_TYPE):
+                self.MERGE_CONTENT_TYPE):
             raise APIError.UnsupportedMedia("PATCH expects content-type %r" %
-                self.MERGE_CONTEXT_TYPE)
+                self.MERGE_CONTENT_TYPE)
 
         try:
             patch = ResourcePatch(patch=json.loads(context.body),

--- a/pale/errors/api_error.py
+++ b/pale/errors/api_error.py
@@ -19,3 +19,8 @@ class APIError(BasePaleError):
         err.http_status_code = 422
         return err
 
+    @classmethod
+    def UnsupportedMedia(cls, message):
+        err = cls(message)
+        err.http_status_code = 415
+        return err

--- a/pale/errors/api_error.py
+++ b/pale/errors/api_error.py
@@ -24,3 +24,9 @@ class APIError(BasePaleError):
         err = cls(message)
         err.http_status_code = 415
         return err
+
+    @classmethod
+    def BadRequest(cls, message):
+        err = cls(message)
+        err.http_status_code = 400
+        return err

--- a/pale/resource.py
+++ b/pale/resource.py
@@ -26,7 +26,7 @@ class Resource(object):
         `Endpoint` does something similar for `arguments`.
         """
         cls._fields = {}
-        if cls.__module__ == __name__:
+        if cls.__module__ == __name__ and cls.__name__ != 'DebugResource':
             return
         for name in set(dir(cls)):
             attr = getattr(cls, name, None)

--- a/tests/example_app/api/endpoints.py
+++ b/tests/example_app/api/endpoints.py
@@ -169,7 +169,7 @@ class ResourcePatchEndpoint(PatchEndpoint):
     _uri = "/resource"
     _route_name = "resource_patch"
 
-    _resource = DebugResource("app resource patch")
+    _resource = DebugResource("resource patch.")
     _returns = DebugResource("app resource.")
 
     def _handle_patch(self, context, patch):

--- a/tests/example_app/api/endpoints.py
+++ b/tests/example_app/api/endpoints.py
@@ -2,6 +2,8 @@ import datetime
 
 from pale import Endpoint
 from pale.arguments import BooleanArgument, IntegerArgument, StringArgument
+from pale.resource import DebugResource
+from pale.errors.api_error import APIError
 from tests.example_app.models import DateTimeModel, DateTimeRangeModel
 from tests.example_app.api.resources import (DateTimeResource,
         DateTimeRangeResource)
@@ -116,3 +118,26 @@ class TimeRangeEndpoint(Endpoint):
         millis = context.args['duration']
         time_range = DateTimeRangeModel(millis*1000) # microseconds
         return {'range': time_range}
+
+
+
+
+MERGE_TYPE = 'application/merge-patch+json'
+class ResourcePatchEndpoint(Endpoint):
+    """
+    """
+
+    _http_method = "PATCH"
+    _uri = "/patch/resource"
+    _route_name = "resource_patch"
+
+    _returns = DebugResource("HM")
+
+    def _handle(self, context):
+        if not context.headers.get('Content-Type').lower() == MERGE_TYPE:
+            raise APIError.UnsupportedMedia("PATCH expects content-type %r" %
+                MERGE_TYPE)
+
+        print context.body
+        return {'yo': 'yo'}
+

--- a/tests/example_app/api/endpoints.py
+++ b/tests/example_app/api/endpoints.py
@@ -1,5 +1,7 @@
 import datetime
 
+from multiprocessing import Manager
+
 from pale import Endpoint, PatchEndpoint
 from pale.arguments import BooleanArgument, IntegerArgument, StringArgument
 from pale.resource import DebugResource
@@ -119,16 +121,60 @@ class TimeRangeEndpoint(Endpoint):
         time_range = DateTimeRangeModel(millis*1000) # microseconds
         return {'range': time_range}
 
+"""
+Resource endpoints.
+We create a multiprocessing memory manager and shared
+dict to enable multithreaded support.
+This 'resource' data is used to test patching.
+"""
+
+BASE_RESOURCE = {
+    'key': 'value'
+}
+MANAGER = Manager()
+RESOURCE = MANAGER.dict(BASE_RESOURCE)
+
+class GetResourceEndpoint(Endpoint):
+    """Returns the 'resource' as it exists in memory.
+    """
+
+    _uri = "/resource"
+    _http_method = 'GET'
+    _route_name = "resource_get"
+
+    _returns = DebugResource("app resource.")
+
+    def _handle(self, context):
+        return dict(RESOURCE)
+
+class ResetResourceEndpoint(Endpoint):
+    """Returns the 'resource' as it exists in memory.
+    """
+
+    _uri = "/resource/reset"
+    _http_method = 'POST'
+    _route_name = "resource_reset"
+
+    _returns = DebugResource("app resource.")
+
+    def _handle(self, context):
+        RESOURCE.clear()
+        RESOURCE.update(BASE_RESOURCE)
+        return dict(RESOURCE)
 
 class ResourcePatchEndpoint(PatchEndpoint):
-    """
+    """Patches a resource which is local to each instance of the app.
     """
 
-    _uri = "/patch/resource"
+    _uri = "/resource"
     _route_name = "resource_patch"
 
-    _returns = DebugResource("HM")
+    _resource = DebugResource("app resource patch")
+    _returns = DebugResource("app resource.")
 
-    def _handle_patch(self, context, data):
-        return data
+    def _handle_patch(self, context, patch):
+        data = dict(RESOURCE)
+        patch.apply_to_dict(data)
+        RESOURCE.update(data)
+        return dict(RESOURCE)
 

--- a/tests/example_app/api/endpoints.py
+++ b/tests/example_app/api/endpoints.py
@@ -1,6 +1,6 @@
 import datetime
 
-from pale import Endpoint
+from pale import Endpoint, PatchEndpoint
 from pale.arguments import BooleanArgument, IntegerArgument, StringArgument
 from pale.resource import DebugResource
 from pale.errors.api_error import APIError
@@ -120,24 +120,15 @@ class TimeRangeEndpoint(Endpoint):
         return {'range': time_range}
 
 
-
-
-MERGE_TYPE = 'application/merge-patch+json'
-class ResourcePatchEndpoint(Endpoint):
+class ResourcePatchEndpoint(PatchEndpoint):
     """
     """
 
-    _http_method = "PATCH"
     _uri = "/patch/resource"
     _route_name = "resource_patch"
 
     _returns = DebugResource("HM")
 
-    def _handle(self, context):
-        if not context.headers.get('Content-Type').lower() == MERGE_TYPE:
-            raise APIError.UnsupportedMedia("PATCH expects content-type %r" %
-                MERGE_TYPE)
-
-        print context.body
-        return {'yo': 'yo'}
+    def _handle_patch(self, context, data):
+        return data
 

--- a/tests/test_flask_adapter.py
+++ b/tests/test_flask_adapter.py
@@ -115,15 +115,30 @@ class FlaskAdapterTests(unittest.TestCase):
         expected_fields = DateTimeResource._all_fields()
         self.assertExpectedFields(end, expected_fields)
 
-    def test_patch(self):
+    def test_resource(self):
 
+        # Start by resetting the resource.
+        # (multiple test runs from the same process will fail otherwise)
+        resp = self.app.post('/api/resource/reset')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json, {'key': 'value'})
+
+        # Test retrieving the resource.
+        resp = self.app.get('/api/resource')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json, {'key': 'value'})
+
+        # Test patching the resource.
         # Without the correct Content-Type, we expect a 415 error.
         self.assertRaises(AppError, self.app.patch_json,
-            '/api/patch/resource', {'this': 'that'})
+            '/api/resource', {'key': 'value2'})
 
-        resp = self.app.patch_json('/api/patch/resource', {'this': 'that'},
+        resp = self.app.patch_json('/api/resource', {'key': 'value2'},
             headers={'Content-Type': 'application/merge-patch+json'})
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json, {'key': 'value2'})
 
-        # print resp.json
-        # assert False, "OK"
+        # Test get to ensure the resource persists.
+        resp = self.app.get('/api/resource')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json, {'key': 'value2'})

--- a/tests/test_flask_adapter.py
+++ b/tests/test_flask_adapter.py
@@ -2,7 +2,7 @@
 import datetime
 import unittest
 
-from webtest import TestApp
+from webtest import TestApp, AppError
 
 from tests.example_app.api.resources import DateTimeResource
 
@@ -114,3 +114,15 @@ class FlaskAdapterTests(unittest.TestCase):
         end = returned_range['end']
         expected_fields = DateTimeResource._all_fields()
         self.assertExpectedFields(end, expected_fields)
+
+    def test_patch(self):
+
+        # Without the correct Content-Type, we expect a 415 error.
+        self.assertRaises(AppError, self.app.patch_json,
+            '/api/patch/resource', {'this': 'that'})
+
+        resp = self.app.patch_json('/api/patch/resource', {'this': 'that'},
+            headers={'Content-Type': 'application/merge-patch+json'})
+        self.assertEqual(resp.status_code, 200)
+        print resp.json
+        assert False, "OK"

--- a/tests/test_flask_adapter.py
+++ b/tests/test_flask_adapter.py
@@ -124,5 +124,6 @@ class FlaskAdapterTests(unittest.TestCase):
         resp = self.app.patch_json('/api/patch/resource', {'this': 'that'},
             headers={'Content-Type': 'application/merge-patch+json'})
         self.assertEqual(resp.status_code, 200)
-        print resp.json
-        assert False, "OK"
+
+        # print resp.json
+        # assert False, "OK"

--- a/tests/test_paledoc.py
+++ b/tests/test_paledoc.py
@@ -3,7 +3,7 @@ import unittest
 
 from pale.doc import generate_doc_dict, generate_json_docs
 
-COUNT_ENDPOINTS = 4
+COUNT_ENDPOINTS = 6
 """Number of endpoints we expect to find in example_app."""
 
 class PaleDocTests(unittest.TestCase):

--- a/tests/test_paledoc.py
+++ b/tests/test_paledoc.py
@@ -3,6 +3,9 @@ import unittest
 
 from pale.doc import generate_doc_dict, generate_json_docs
 
+COUNT_ENDPOINTS = 4
+"""Number of endpoints we expect to find in example_app."""
+
 class PaleDocTests(unittest.TestCase):
     def setUp(self):
         super(PaleDocTests, self).setUp()
@@ -32,8 +35,8 @@ class PaleDocTests(unittest.TestCase):
 
     def test_endpoint_without_args_docs(self):
         endpoints = self.doc_dict['endpoints']
-        # we defined three endpoints in the example app
-        self.assertEqual(len(endpoints), 3)
+        # we defined n endpoints in the example app
+        self.assertEqual(len(endpoints), COUNT_ENDPOINTS)
 
         # the current time endpoint
         current_time_doc = endpoints['current_time']
@@ -51,8 +54,8 @@ class PaleDocTests(unittest.TestCase):
 
     def test_endpoint_with_args_docs(self):
         endpoints = self.doc_dict['endpoints']
-        # we defined three endpoints in the example app
-        self.assertEqual(len(endpoints), 3)
+        # we defined n endpoints in the example app
+        self.assertEqual(len(endpoints), COUNT_ENDPOINTS)
 
         # the current time endpoint
         parse_time_doc = endpoints['parse_time']
@@ -129,8 +132,8 @@ class PaleDocTests(unittest.TestCase):
 
     def test_resource_doc(self):
         resources = self.doc_dict['resources']
-        # we defined two resources in the example app
-        self.assertEqual(len(resources), 2)
+        # we defined n resources in the example app
+        self.assertEqual(len(resources), 3)
 
         resource = resources['DateTime Resource']
         self.assertEqual(resource['name'], 'DateTime Resource')

--- a/tests/test_resource_patch.py
+++ b/tests/test_resource_patch.py
@@ -11,6 +11,12 @@ class Stats(object):
         self.logins = 0
 
 
+class Counter(object):
+    def __init__(self, key, value=0):
+        self.key = key
+        self.value = value
+
+
 class StatsResource(Resource):
     _value_type = 'Test "stats" resource for patches'
     _underlying_model = Stats
@@ -18,13 +24,30 @@ class StatsResource(Resource):
     logins = IntegerField("Number of logins")
 
 
+class CounterResource(Resource):
+    _value_type = 'Test repeated nested resources'
+    _underlying_model = Counter
+
+    name = StringField("Name of counter",
+        property_name='key')
+    value = IntegerField("Value of counter")
+
+
 class User(object):
+    """Has:
+    tokens - list of strings
+    counters - list of Counter
+    id - string id
+    username - string username
+    """
     def __init__(self, id, username):
         assert isinstance(username, basestring)
         self.username = username
         assert isinstance(id, basestring)
         self.id = id
         self.stats = Stats()
+        self.counters = []
+        self.tokens = []
 
 
 class UserResource(Resource):
@@ -35,6 +58,12 @@ class UserResource(Resource):
     id = StringField("User ID")
     stats = ResourceField("Test of a nested resource",
         resource_type=StatsResource)
+
+    counters = ResourceListField("List of misc. counters",
+        resource_type=CounterResource)
+
+    tokens = ListField("List of string tokens",
+        item_type=StringField)
 
 
 class ResourcePatchTests(unittest.TestCase):
@@ -53,7 +82,13 @@ class ResourcePatchTests(unittest.TestCase):
             'username': 'ammoses',
             'stats': {
                 'logins': 12
-            }
+            },
+            'counters': [
+                {'name': 'products', 'value': 36}
+            ],
+            'tokens': [
+                'gold-coin'
+            ]
         }
 
         user_resouce = UserResource()
@@ -61,12 +96,17 @@ class ResourcePatchTests(unittest.TestCase):
         dt = user_resouce._render_serializable(user, None)
         self.assertEqual(dt['username'], 'soundofjw')
         self.assertEqual(dt['stats']['logins'], 0)
+        self.assertEqual(dt['counters'], [])
+        self.assertEqual(dt['tokens'], [])
 
         patch = ResourcePatch(patch_data, user_resouce)
 
         patch.apply_to_model(user)
+
         dt = user_resouce._render_serializable(user, None)
         self.assertEqual(dt['username'], 'ammoses')
         self.assertEqual(dt['stats']['logins'], 12)
+        self.assertEqual(dt['counters'][0], {'name': 'products', 'value': 36})
+        self.assertEqual(dt['tokens'][0], 'gold-coin')
 
 

--- a/tests/test_resource_patch.py
+++ b/tests/test_resource_patch.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from pale import Resource, ResourcePatch
+from pale.fields import (BaseField, IntegerField, ListField, ResourceField,
+        ResourceListField, StringField)
+
+class User(object):
+    def __init__(self, id, username):
+        self.logins = 0
+        assert isinstance(username, basestring)
+        self.username = username
+        assert isinstance(id, basestring)
+        self.id = id
+
+
+class UserResource(Resource):
+    _value_type = 'Test "user" resource for patches'
+    _underlying_model = User
+
+    username = StringField("Username")
+    logins = IntegerField("Number of logins")
+    id = StringField("User ID")
+
+
+class ResourcePatchTests(unittest.TestCase):
+
+    def setUp(self):
+        super(ResourcePatchTests, self).setUp()
+
+    def test_patch_resource(self):
+
+        user = User(
+            id="001",
+            username="soundofjw",
+            )
+
+        patch_data = {
+            'username': 'ammoses',
+            'logins': 12
+        }
+
+        user_resouce = UserResource()
+        patch = ResourcePatch(patch_data, user_resouce)
+
+        patch.apply_to_model(user)
+        dt = user_resouce._render_serializable(user, None)
+        self.assertEqual(dt['username'], 'ammoses')
+        self.assertEqual(dt['logins'], 12)
+
+


### PR DESCRIPTION
Support for [RFC7386](https://tools.ietf.org/html/rfc7386), which is a JSON Merge Patch HTTP request specification using the `PATCH` HTTP method.