### PR TITLE
Fix handling of blank JSON documents

### DIFF
--- a/pale/doc.py
+++ b/pale/doc.py
@@ -141,6 +141,8 @@ def document_resource(resource):
         'name': resource._value_type,
         'description': py_doc_trim(resource.__doc__),
         'fields': field_doc,
-        'default_fields': list(resource._default_fields)
+        'default_fields': None,
     }
+    if resource._default_fields:
+        res_doc['default_fields'] = list(resource._default_fields)
     return res_doc

--- a/pale/endpoint.py
+++ b/pale/endpoint.py
@@ -211,13 +211,17 @@ class Endpoint(object):
                 message = "You don't have permission to do that."
             err = APIError.Forbidden(message)
             response = self._response_class(*err.response)
+            response.headers["Content-Type"] = 'application/json'
         except ArgumentError as e:
             err = APIError.UnprocessableEntity(e.message)
             response = self._response_class(*err.response)
+            response.headers["Content-Type"] = 'application/json'
         except APIError as e:
             response = self._response_class(*e.response)
+            response.headers["Content-Type"] = 'application/json'
         except PaleRaisedResponse as r:
             response = self._response_class(*r.response)
+            response.headers["Content-Type"] = 'application/json'
         except Exception as e:
             logging.exception(e)
             raise
@@ -238,11 +242,6 @@ class Endpoint(object):
                 "Failed to process _after_response_handlers for Endpoint %s"
                 % self.__class__.__name__)
             raise
-
-        # ensure content type is json
-        if "Content-Type" not in response.headers or \
-                response.headers["Content-Type"] != "application/json":
-            response.headers["Content-Type"] = "application/json"
 
         return response
 
@@ -378,7 +377,10 @@ class Endpoint(object):
                     self._default_cache
 
         # Add default json response type.
-        self._context.response.headers["Content-Type"] = "application/json"
+        if len(json_content):
+            self._context.response.headers["Content-Type"] = 'application/json'
+        else:
+            del self._context.response.headers["Content-Type"]
 
 
 class ResourcePatch(object):

--- a/tests/example_app/api/endpoints.py
+++ b/tests/example_app/api/endpoints.py
@@ -225,4 +225,4 @@ class BlankEndpoint(Endpoint):
     _returns = NoContentResource()
 
     def _handle(self, context):
-        return {}
+        return None

--- a/tests/example_app/api/endpoints.py
+++ b/tests/example_app/api/endpoints.py
@@ -4,7 +4,7 @@ from multiprocessing import Manager
 
 from pale import Endpoint, PatchEndpoint, PutResourceEndpoint
 from pale.arguments import BooleanArgument, IntegerArgument, StringArgument
-from pale.resource import DebugResource
+from pale.resource import DebugResource, NoContentResource
 from pale.errors.api_error import APIError
 from tests.example_app.models import DateTimeModel, DateTimeRangeModel
 from tests.example_app.api.resources import (DateTimeResource,
@@ -213,3 +213,16 @@ class ResourceCreateEndpoint(PutResourceEndpoint):
         RESOURCE.update(data)
         return dict(RESOURCE)
 
+
+class BlankEndpoint(Endpoint):
+    """ This carries out some action, then returns nothing on success.
+    """
+    _http_method = "POST"
+    _uri = "/blank"
+    _route_name = "resource_blank"
+    _allow_cors = True
+
+    _returns = NoContentResource()
+
+    def _handle(self, context):
+        return {}

--- a/tests/test_flask_adapter.py
+++ b/tests/test_flask_adapter.py
@@ -135,17 +135,20 @@ class FlaskAdapterTests(unittest.TestCase):
         # (multiple test runs from the same process will fail otherwise)
         resp = self.app.post('/api/resource/reset')
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.json, {'key': 'value'})
 
         # Test creating a new resource
         resp = self.app.put_json('/api/resource', {'key': 'boop'},
             headers={'Content-Type': 'application/json'})
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.json, {'key': 'boop'})
 
         # Test retrieving the resource.
         resp = self.app.get('/api/resource')
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.json, {'key': 'boop'})
 
         # Test patching the resource.
@@ -156,9 +159,11 @@ class FlaskAdapterTests(unittest.TestCase):
         resp = self.app.patch_json('/api/resource', {'key': 'value2'},
             headers={'Content-Type': 'application/merge-patch+json'})
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.json, {'key': 'value2'})
 
         # Test get to ensure the resource persists.
         resp = self.app.get('/api/resource')
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.json, {'key': 'value2'})

--- a/tests/test_flask_adapter.py
+++ b/tests/test_flask_adapter.py
@@ -167,3 +167,8 @@ class FlaskAdapterTests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.json, {'key': 'value2'})
+
+        # A NoContentResource shouldn't have a Content-Type header (no content!)
+        resp = self.app.post('/api/blank')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content_type, None)

--- a/tests/test_paledoc.py
+++ b/tests/test_paledoc.py
@@ -3,7 +3,7 @@ import unittest
 
 from pale.doc import generate_doc_dict, generate_json_docs
 
-COUNT_ENDPOINTS = 8
+COUNT_ENDPOINTS = 9
 """Number of endpoints we expect to find in example_app."""
 
 class PaleDocTests(unittest.TestCase):


### PR DESCRIPTION
Adds tests for Content-Type checking. Webtest was already ensuring an appropriate Content-Type before, but this could include things like `application/foo+json`.

Verifies that no Content-Type is sent for a NoContentResource.

Fixes `paledoc` handling of NoContentType, maybe there's a better way to do this though.