### PR TITLE
API doc cleanup

### DIFF
--- a/pale/doc.py
+++ b/pale/doc.py
@@ -748,7 +748,7 @@ def generate_doc_dict(module):
 
 def document_endpoint(endpoint):
     """Extract the full documentation dictionary from the endpoint."""
-    descr = py_doc_trim(endpoint.__doc__)
+    descr = clean_description(py_doc_trim(endpoint.__doc__))
     docs = {
         'name': endpoint._route_name,
         'http_method': endpoint._http_method,
@@ -781,17 +781,17 @@ def format_endpoint_argument_doc(argument):
     doc = argument.doc_dict()
 
     # Trim the strings a bit
-    doc['description'] = py_doc_trim(doc['description'])
+    doc['description'] = clean_description(py_doc_trim(doc['description']))
     details = doc.get('detailed_description', None)
     if details is not None:
-        doc['detailed_description'] = py_doc_trim(details)
+        doc['detailed_description'] = clean_description(py_doc_trim(details))
 
     return doc
 
 
 def format_endpoint_returns_doc(endpoint):
     """Return documentation about the resource that an endpoint returns."""
-    description = py_doc_trim(endpoint._returns._description)
+    description = clean_description(py_doc_trim(endpoint._returns._description))
     return {
         'description': description,
         'resource_name': endpoint._returns._value_type,
@@ -805,10 +805,11 @@ def document_resource(resource):
 
     res_doc = {
         'name': resource._value_type,
-        'description': py_doc_trim(resource.__doc__),
+        'description': clean_description(py_doc_trim(resource.__doc__)),
         'fields': field_doc,
         'default_fields': None,
     }
     if resource._default_fields:
         res_doc['default_fields'] = list(resource._default_fields)
+        # @TODO start here - loop through res_doc["default_fields"] and clean descriptions
     return res_doc

--- a/pale/doc.py
+++ b/pale/doc.py
@@ -102,7 +102,7 @@ def generate_json_docs(module, pretty_print=False, user=None):
     return json_str
 
 
-def generate_raml_docs(module, fields, shared_types, user=None, title="My API", version="v1", api_root="api", base_uri="http://mysite.com/{apiRoot}/{version}"):
+def generate_raml_docs(module, fields, shared_types, user=None, title="My API", version="v1", api_root="api", base_uri="http://mysite.com/{version}"):
     """Return a RAML file of a Pale module's documentation as a string.
 
     The user argument is optional. If included, it expects the user to be an object with an "is_admin"
@@ -118,11 +118,7 @@ def generate_raml_docs(module, fields, shared_types, user=None, title="My API", 
     output.write('title: ' + title + ' \n')
     output.write('baseUri: ' + base_uri + ' \n')
     output.write('version: ' + version + '\n')
-    output.write('apiRoot: ' + api_root + '\n')
-    output.write('mediaType: application/json\n')
-    output.write('baseUriParameters:\n')
-    output.write('  apiRoot:\n')
-    output.write('    description: Root directory of this API\n\n')
+    output.write('mediaType: application/json\n\n')
     output.write("###############\n# Resource Types:\n###############\n\n")
     output.write('types:\n')
 

--- a/pale/doc.py
+++ b/pale/doc.py
@@ -759,26 +759,20 @@ def generate_raml_resources(module, api_root, user):
             admin_user = user!= None and user.is_admin != None and user.is_admin
 
             for branch in subtree:
-                # if the user is admin:
-                if admin_user:
-                    # write the branch name
-                    output.write(indent + "/" + branch + ":\n")
-                    # and continue printing the endpoints
-                    print_resource_tree(subtree[branch], output, indent, user, level=level+1)
 
-                # endpoint_is_private = subtree[branch].get("endpoint") != None and subtree[branch]["endpoint"].get("requires_permission") != None
-                endpoint_is_private = True
-                # has_public_children = check_children_for_public_endpoints(subtree[branch])["public"]
-                has_public_children = True
+                has_public_children = check_children_for_public_endpoints(subtree[branch]).get("public") == True
 
-                endpoint_qualifies = endpoint_is_private and has_public_children
+                is_public_endpoint = subtree[branch].get("endpoint") != None \
+                    and subtree[branch]["endpoint"].get("requires_permission") == None
 
-                # or if user is not admin, and this endpoint is private, and it has public children:
-                elif True: # @TODO where is the syntax error?
+                # @TODO - make this permission more granular if necessary
+                # if the user is admin or this endpoint is pubic or has public children:
+                if admin_user or has_public_children or is_public_endpoint:
                     # write branch name
                     output.write(indent + "/" + branch + ":\n")
                     # and continue printing the endpoints
                     print_resource_tree(subtree[branch], output, indent, user, level=level+1)
+
 
 
     output = StringIO()

--- a/pale/doc.py
+++ b/pale/doc.py
@@ -673,7 +673,10 @@ def generate_raml_resources(module, api_root, user):
                                 if this_arg_detail != None:
 
                                     if arg_detail == "default":
-                                        output.write(indent + arg_detail + ": " + str(this_arg_detail) + "\n")
+                                        default = str(this_arg_detail)
+                                        if default == "True" or default == "False":
+                                            default = default.lower()
+                                        output.write(indent + arg_detail + ": " + default + "\n")
                                     elif arg_detail == "description":
                                         output.write(indent + "description: " + this_arg_detail + "\n")
                                     elif arg_detail == "type":

--- a/pale/doc.py
+++ b/pale/doc.py
@@ -603,21 +603,6 @@ def generate_raml_resources(module, api_root, user):
         "ListArgument": "array"
     }
 
-    def check_subtree_for_permissions(subtree, api_root, private_endpoints={}):
-        """Recursively check a subtree to see if any of its children require permissions.
-        Returns a map of private endpoints, where the key is the endpoint's URI and the
-        value is a dict with a requires_permission property equal to the permission required."""
-
-        if subtree.get("path") != None and len(subtree["path"]) > 0:
-            path = subtree["path"]
-            for branch in path:
-                if path[branch].get("endpoint") != None and path[branch]["endpoint"].get("requires_permission") != None \
-                and branch != api_root:
-                    private_endpoints[branch] = {}
-                    private_endpoints[branch]["requires_permission"] = path[branch]["endpoint"]["requires_permission"]
-                check_subtree_for_permissions(path[branch], private_endpoints)
-
-        return private_endpoints
 
     def check_children_for_public_endpoints(subtree):
         """Recursively check a subtree to see if any of its children require permissions.

--- a/pale/doc.py
+++ b/pale/doc.py
@@ -59,14 +59,16 @@ def clean_description(string):
     newlines = re.compile(r"\n")
     colons = re.compile(r":(?!//)")
     machine_code = re.compile(r"(<.+>)")
-    punctuation = re.compile(r"[\.!?,]")
+    trailing_whitespace = re.compile(r"(\s+\Z)")
+    punctuation = re.compile(r"([\.!?,])\s*\Z")
 
     result = leading_whitespace.sub("", string, 0)
     result = newlines.sub(" ", result, 0)
     result = colons.sub('=', result, 0)
     result = machine_code.sub("", result, 0)
     result = multiple_spaces.sub(" ", result, 0)
-    has_punctuation = punctuation.search(result[-1:]) != None
+    result = trailing_whitespace.sub("", result, 0)
+    has_punctuation = punctuation.search(result) != None
 
     if not has_punctuation and result != "":
         result = result + "."

--- a/pale/doc.py
+++ b/pale/doc.py
@@ -68,7 +68,7 @@ def clean_description(string):
     result = multiple_spaces.sub(" ", result, 0)
     has_punctuation = punctuation.search(result[-1:]) != None
 
-    if not has_punctuation:
+    if not has_punctuation and result != "":
         result = result + "."
     else:
         result = result
@@ -115,7 +115,6 @@ def generate_raml_docs(module, fields, shared_types, user=None, title="My API", 
     output.write('baseUri: ' + base_uri + ' \n')
     output.write('version: ' + version + '\n')
     output.write('mediaType: application/json\n\n')
-
     output.write("###############\n# Resource Types:\n###############\n\n")
     output.write('types:\n')
 
@@ -800,8 +799,16 @@ def format_endpoint_returns_doc(endpoint):
 
 
 def document_resource(resource):
-    field_doc = { name: field.doc_dict() for name, field \
-            in resource._fields.iteritems() }
+
+    field_doc = {}
+
+    for name, field in resource._fields.iteritems():
+        doc_dict = field.doc_dict()
+        if doc_dict.get("description") != None:
+            doc_dict["description"] = clean_description(doc_dict["description"])
+        if doc_dict.get("extended_description") != None:
+            doc_dict["extended_description"] = clean_description(doc_dict["extended_description"])
+        field_doc[name] = doc_dict
 
     res_doc = {
         'name': resource._value_type,
@@ -811,5 +818,4 @@ def document_resource(resource):
     }
     if resource._default_fields:
         res_doc['default_fields'] = list(resource._default_fields)
-        # @TODO start here - loop through res_doc["default_fields"] and clean descriptions
     return res_doc

--- a/pale/doc.py
+++ b/pale/doc.py
@@ -119,7 +119,14 @@ def generate_raml_docs(module, fields, shared_types, user=None, title="My API", 
     output.write('baseUri: ' + base_uri + ' \n')
     output.write('version: ' + version + '\n')
     output.write('mediaType: application/json\n\n')
-    output.write("###############\n# Resource Types:\n###############\n\n")
+    output.write('documentation:\n')
+    output.write('  - title: Welcome\n')
+    output.write('    content: |\n')
+    output.write("""\
+        Welcome to the Loudr API Docs.\n
+        You'll find comprehensive documentation on our endpoints and resources here.
+        """)
+    output.write("\n###############\n# Resource Types:\n###############\n\n")
     output.write('types:\n')
 
     basic_fields = []

--- a/tests/test_paledoc.py
+++ b/tests/test_paledoc.py
@@ -86,7 +86,7 @@ class PaleDocTests(unittest.TestCase):
         # the year argument
         year_arg = args['year']
         self.assertEqual(year_arg['description'],
-                "Set the year of the returned datetime")
+                "Set the year of the returned datetime.")
         self.assertFalse('detailed_description' in year_arg)
         self.assertEqual(year_arg['type'], 'IntegerArgument')
         self.assertEqual(year_arg['default'], 2015)
@@ -95,7 +95,7 @@ class PaleDocTests(unittest.TestCase):
         # month, which has min and max values
         month_arg = args['month']
         self.assertEqual(month_arg['description'],
-                "Set the month of the returned datetime")
+                "Set the month of the returned datetime.")
         self.assertFalse('detailed_description' in month_arg)
         self.assertEqual(month_arg['type'], 'IntegerArgument')
         self.assertEqual(month_arg['default'], None)
@@ -106,7 +106,7 @@ class PaleDocTests(unittest.TestCase):
         # day, which is barebones
         day_arg = args['day']
         self.assertEqual(day_arg['description'],
-                "Set the day of the returned datetime")
+                "Set the day of the returned datetime.")
         self.assertFalse('detailed_description' in day_arg)
         self.assertEqual(day_arg['type'], 'IntegerArgument')
         self.assertEqual(day_arg['default'], None)
@@ -115,7 +115,7 @@ class PaleDocTests(unittest.TestCase):
         # name arg
         name_arg = args['name']
         self.assertEqual(name_arg['description'],
-                "The name for your datetime")
+                "The name for your datetime.")
         self.assertEqual(name_arg['detailed_description'],
                 "You can give your time a name, which will be returned back to you in the response, as the field `name`. If you omit this input parameter, your response won't include a `name`.")
         self.assertEqual(name_arg['type'], 'StringArgument')
@@ -153,6 +153,9 @@ class PaleDocTests(unittest.TestCase):
         self.assertEquals(test_machine_code, "(with code in it).")
         test_punctuation = clean_description("hanging")
         self.assertEquals(test_punctuation, "hanging.")
+        test_empty_string = clean_description("")
+        self.assertEquals(test_empty_string, "",
+            "Leaves empty strings as they are.")
 
 
     def test_resource_doc(self):
@@ -168,7 +171,7 @@ class PaleDocTests(unittest.TestCase):
         resource = resources['DateTime Range Resource']
         self.assertEqual(resource['name'], 'DateTime Range Resource')
         self.assertEqual(resource['description'],
-                'A time range that returns some nested resources')
+                'A time range that returns some nested resources.')
 
 
     def test_generate_basic_type_docs(self):

--- a/tests/test_paledoc.py
+++ b/tests/test_paledoc.py
@@ -258,6 +258,8 @@ class PaleDocTests(unittest.TestCase):
                 """Does not contain the machine code version of string formatting, like
                 '<pale.fields.string.StringField object at 0x1132bd2d0>'
                 for example""")
+        self.assertTrue("default: False" not in test_resources_admin,
+                "Converts upper-cased Booleans to lower-cased Booleans")
 
         test_resources_public = generate_raml_resources(self.example_app, "", test_public_user)
         test_restricted_resource = "Include the time in the output?"

--- a/tests/test_paledoc.py
+++ b/tests/test_paledoc.py
@@ -9,6 +9,12 @@ from pale.doc import generate_doc_dict, generate_json_docs, generate_basic_type_
 COUNT_ENDPOINTS = 9
 """Number of endpoints we expect to find in example_app."""
 
+class User(object):
+    def __init__(self):
+        self.is_admin = True
+
+test_user = User()
+
 class PaleDocTests(unittest.TestCase):
     def setUp(self):
         super(PaleDocTests, self).setUp()
@@ -16,7 +22,7 @@ class PaleDocTests(unittest.TestCase):
         from pale import fields
         self.example_app = example_pale_app
         self.example_fields = fields
-        self.doc_dict = generate_doc_dict(self.example_app)
+        self.doc_dict = generate_doc_dict(self.example_app, test_user)
 
 
     def test_doc_dict_root_structure(self):
@@ -28,7 +34,7 @@ class PaleDocTests(unittest.TestCase):
 
 
     def test_doc_json(self):
-        json_docs = generate_json_docs(self.example_app)
+        json_docs = generate_json_docs(self.example_app, pretty_print=False, user=test_user)
 
         # use yaml's safe_load here, because it returns strings instead
         # of unicode, and we know that our test data doesn't have any
@@ -204,7 +210,7 @@ class PaleDocTests(unittest.TestCase):
         from pale import extract_endpoints, extract_resources, is_pale_module
         raml_resources = extract_endpoints(self.example_app)
         raml_resource_doc_flat = { ep._route_name: document_endpoint(ep) for ep in raml_resources }
-        test_tree = generate_raml_tree(raml_resource_doc_flat, version="")
+        test_tree = generate_raml_tree(raml_resource_doc_flat, api_root="api")
 
         # check if the tree is parsing the URIs correctly
         self.assertTrue(test_tree.get("path") != None)

--- a/tests/test_paledoc.py
+++ b/tests/test_paledoc.py
@@ -162,6 +162,8 @@ class PaleDocTests(unittest.TestCase):
         test_empty_string = clean_description("")
         self.assertEquals(test_empty_string, "",
             "Leaves empty strings as they are.")
+        test_trailing_whitespace = clean_description("Is this the end?    ")
+        self.assertEquals(test_trailing_whitespace, "Is this the end?")
 
 
     def test_resource_doc(self):


### PR DESCRIPTION
Applies the same logic for cleaning descriptions to the JSON docs as was used recently for the RAML docs.

Adds `api_root` as a `baseUriParameter` to separate out the `/api` part of `https://loudr.fm/api`.

Also fixes an earlier implementation of user permissions so that the RAML output renders correctly.

Closes #59 