### PR TITLE
Store context in a thread-safe variable.

### DIFF
--- a/pale/adapters/webapp2.py
+++ b/pale/adapters/webapp2.py
@@ -32,7 +32,12 @@ def pale_webapp2_request_handler_generator(pale_endpoint):
             self.response.headers['Access-Control-Allow-Methods'] = 'POST, GET, PUT, DELETE'
             self.response.headers['Access-Control-Allow-Credentials'] = 'true'
             return self.response
-        return pale_endpoint._execute(self.request)
+
+        try:
+            return pale_endpoint._execute(self.request)
+        finally:
+            pale_endpoint._finally()
+
     cls = type(pale_endpoint._route_name,
             (webapp2.RequestHandler,),
             dict(pale_handler=pale_handler))
@@ -83,7 +88,7 @@ class DefaultWebapp2Context(pale.context.DefaultContext):
 
     def build_args_from_request(self, request):
         keys = request.arguments()
-        req_args = {}
+        req_args = dict()
 
         for key in keys:
             req_args[key] = request.get_all(key)

--- a/pale/context.py
+++ b/pale/context.py
@@ -2,17 +2,18 @@
 
 class DefaultContext(object):
     """A default Context object for pale request data"""
-    request = None
-    headers = None
-    cookies = None
+    def __init__(self):
+        self.request = None
+        self.headers = None
+        self.cookies = None
 
-    api_version = None
+        self.api_version = None
 
-    _raw_args = None
-    args = None
-    route_args = None
+        self._raw_args = None
+        self.args = None
+        self.route_args = None
 
-    current_user = None
+        self.current_user = None
 
-    handler_result = None
-    response = None
+        self.handler_result = None
+        self.response = None


### PR DESCRIPTION
Currently, each Endpoint instance carries the pale context
in an instance variable called `_context`.

Because the Endpoint instance is global, and not thread-local,
we need to store the `_context` object in a thread-safe variable
provided by threading.local().

Additionally, a `_finally()` method is added to `Endpoint` and
is called when `_execute()` completes, regardless of success.
This is intended for any cleanup the Endpoint may need to do.

This patch also provides docstring updates to various methods.